### PR TITLE
Resolves #7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
      install_requires=[
-          'nltk', 'sklearn', 'sklearn_crfsuite', 'gensim'
+          'nltk', 'scikit-learn', 'sklearn_crfsuite', 'gensim'
       ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
For issue#7, fix the dependency of package name from deprecated  'sklearn' to 'scikit-learn'